### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ export default pipe(
     }
   )
 
-// And you an directly return the pipeline object to `eslint.config.mjs`
+// And you can directly return the pipeline object to `eslint.config.mjs`
 ```
 
 ## Sponsors

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Concatenate multiple ESLint flat configs into one, resolve the promises, and fla
 
 ```ts
 // eslint.config.mjs
-import { conact } from 'eslint-flat-config-utils'
+import { concat } from 'eslint-flat-config-utils'
 
-export default conact(
+export default concat(
   {
     plugins: {},
     rules: {},


### PR DESCRIPTION
### Description

Corrects "concat" and "can" typos in README.
