### PR TITLE
fix: sort plugin length for rename

### DIFF
--- a/src/rename.ts
+++ b/src/rename.ts
@@ -19,10 +19,12 @@ import type { Linter } from 'eslint'
  * ```
  */
 export function renamePluginsInRules(rules: Record<string, any>, map: Record<string, string>): Record<string, any> {
+  const entries = Object.entries(map).sort(([a], [b]) => b.length - a.length)
+
   return Object.fromEntries(
     Object.entries(rules)
       .map(([key, value]) => {
-        for (const [from, to] of Object.entries(map)) {
+        for (const [from, to] of entries) {
           if (key.startsWith(`${from}/`))
             return [to + key.slice(from.length), value]
         }

--- a/test/rename.test.ts
+++ b/test/rename.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from 'vitest'
+import { renamePluginsInRules } from '../src/rename'
+
+it('renames rules with shared plugin prefixes using the longest match first', () => {
+  const renamed = renamePluginsInRules(
+    {
+      '@eslint-react/debug/jsx': 'error',
+      '@eslint-react/dom/no-dangerously-set-innerhtml': 'error',
+      '@eslint-react/naming-convention/component-name': 'error',
+      '@eslint-react/no-access-state-in-setstate': 'error',
+      '@eslint-react/rsc/no-client-hook-in-server-component': 'error',
+      '@eslint-react/web-api/no-leaked-event-listener': 'error',
+      'no-console': 'off',
+    },
+    {
+      '@eslint-react': 'react',
+      '@eslint-react/dom': 'react-dom',
+      '@eslint-react/naming-convention': 'react-naming-convention',
+      '@eslint-react/rsc': 'react-rsc',
+      '@eslint-react/web-api': 'react-web-api',
+    },
+  )
+
+  expect(renamed).toEqual({
+    'react/debug/jsx': 'error',
+    'react-dom/no-dangerously-set-innerhtml': 'error',
+    'react-naming-convention/component-name': 'error',
+    'react/no-access-state-in-setstate': 'error',
+    'react-rsc/no-client-hook-in-server-component': 'error',
+    'react-web-api/no-leaked-event-listener': 'error',
+    'no-console': 'off',
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

```diff
  {
    "no-console": "off",
-   "react-dom/no-dangerously-set-innerhtml": "error",
-   "react-naming-convention/component-name": "error",
-   "react-rsc/no-client-hook-in-server-component": "error",
-   "react-web-api/no-leaked-event-listener": "error",
    "react/debug/jsx": "error",
+   "react/dom/no-dangerously-set-innerhtml": "error",
+   "react/naming-convention/component-name": "error",
    "react/no-access-state-in-setstate": "error",
+   "react/rsc/no-client-hook-in-server-component": "error",
+   "react/web-api/no-leaked-event-listener": "error",
  }
```

### Linked Issues

fixes #<number>

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
