### PR TITLE
fix: allow auto-complete for `ConfigNames` in composer.replace

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -315,7 +315,7 @@ export class FlatConfigComposer<
   /**
    * Remove a specific config by name or index.
    */
-  public remove(nameOrIndex: ConfigNames | string | number): this {
+  public remove(nameOrIndex: StringLiteralUnion<ConfigNames, string | number>): this {
     this._operations.push(async (configs) => {
       const index = getConfigIndex(configs, nameOrIndex)
       configs.splice(index, 1)


### PR DESCRIPTION
Before, autocomplete did not work when using composer.replace, seems like a simple oversight