### PR TITLE
fix(node): support v20

### DIFF
--- a/src/rename.ts
+++ b/src/rename.ts
@@ -76,17 +76,25 @@ export function renamePluginsInConfigs<T extends Linter.Config = Linter.Config>(
           return [key, value]
         })
 
-      const grouped = Object.groupBy(renamed, entry => entry[0])
+      // use Object.groupBy Node 20 is EOL (2026-04-30, see https://github.com/antfu/eslint-flat-config-utils/pull/12)
+      const grouped = renamed.reduce<Record<string, [string, Plugin][]>>((acc, entry) => {
+        const k = entry[0]
+        if (!acc[k])
+          acc[k] = []
+        acc[k].push(entry)
+        return acc
+      }, {})
+
       const shouldMerge = options?.mergePlugins ?? false
 
       clone.plugins = Object.fromEntries(
         Object.entries(grouped).map(([key, values]) => {
           if (shouldMerge)
-            return [key, mergePlugins(...values!.map(entry => entry[1]))!]
+            return [key, mergePlugins(...values.map(entry => entry[1]))!]
 
-          if (values!.length > 1)
+          if (values.length > 1)
             console.warn(`ESLintFlatConfigUtils: Trying to rename multiple plugins to the name "${key}", using the last one`)
-          return values!.at(-1)!
+          return values.at(-1)!
         }),
       )
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

`Object.groupBy` is not available in NodeJS v20 which is still alive.

### Linked Issues

fixes #11

### Additional context

Node v20 will be EOL end of the month.
I wonder if there is a possibility to automatically test lowest and highest non-EOL node version, maybe something like:

```diff
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index fb78617..0788aa1 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,29 @@ jobs:
       - name: Typecheck
         run: nr typecheck
 
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Setup node for matrix job
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Compute Node LTS matrix
+        id: set-matrix
+        run: |
+          node -e "const https=require('https');https.get('https://raw.githubusercontent.com/nodejs/Release/main/schedule.json',res=>{let s='';res.on('data',c=>s+=c);res.on('end',()=>{const j=JSON.parse(s);const now=Date.now();const nonEol=Object.entries(j).filter(([k,v])=>{const end=new Date(v.end).getTime();return end>now && v.lts});const majors=nonEol.map(([k])=>parseInt(k,10)).sort((a,b)=>a-b);if(majors.length===0){console.error('no lts');process.exit(1)};const out=[majors[0],majors[majors.length-1]];require('fs').writeFileSync('matrix.json',JSON.stringify(out));console.log('matrix',JSON.stringify(out));})})"
+          echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
+
   test:
+    needs: prepare-matrix
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
```
But would be cool to have this info be part of `actions/setup-node` maybe, the fetching is not cool of course.